### PR TITLE
JS JustifiedGalleryController stop progressive image sizing

### DIFF
--- a/app/frontend/packs/controllers/justified_gallery_controller.js
+++ b/app/frontend/packs/controllers/justified_gallery_controller.js
@@ -45,10 +45,13 @@ export default class extends Controller {
       containerWidth: this.containerTarget.clientWidth,
       targetRowHeight: 295
     }
+    console.log('this.containerTarget.parentElement.clientWidth', this.containerTarget.parentElement.clientWidth)
+    console.log('this.containerTarget.clientWidth', this.containerTarget.clientWidth)
     const geometry = justifiedLayout(geometryInput, config)
     for (let i = 0; i < this.galleryItemTargets.length; i++) {
       this.galleryItemTargets[i].width = geometry.boxes[i].width
       this.galleryItemTargets[i].height = geometry.boxes[i].height
+      this.galleryItemTargets[i].style.position = 'relative'
     }
   }
 

--- a/app/frontend/packs/controllers/justified_gallery_controller.js
+++ b/app/frontend/packs/controllers/justified_gallery_controller.js
@@ -45,8 +45,6 @@ export default class extends Controller {
       containerWidth: this.containerTarget.clientWidth,
       targetRowHeight: 295
     }
-    console.log('this.containerTarget.parentElement.clientWidth', this.containerTarget.parentElement.clientWidth)
-    console.log('this.containerTarget.clientWidth', this.containerTarget.clientWidth)
     const geometry = justifiedLayout(geometryInput, config)
     for (let i = 0; i < this.galleryItemTargets.length; i++) {
       this.galleryItemTargets[i].width = geometry.boxes[i].width

--- a/app/frontend/packs/styles/custom/gallery.scss
+++ b/app/frontend/packs/styles/custom/gallery.scss
@@ -16,6 +16,7 @@
   padding-inline-start: 0;
   position: relative;
   width: 100%;
+  overflow: hidden;
 }
 
 .gallery-image-container {

--- a/app/frontend/packs/styles/custom/gallery.scss
+++ b/app/frontend/packs/styles/custom/gallery.scss
@@ -1,3 +1,8 @@
+.gallery {
+  position: relative;
+  width: 100%;
+}
+
 .gallery-container {
   display: flex;
   flex-wrap: wrap;
@@ -9,6 +14,7 @@
   margin-inline-end: 0;
   margin-inline-start: 0;
   padding-inline-start: 0;
+  position: relative;
   width: 100%;
 }
 
@@ -29,5 +35,6 @@
 .gallery-image-thumbnail {
   object-fit: cover;
   opacity: 0;
+  position: absolute;
   transition: opacity 0.7s cubic-bezier(0.76, 0.24, 0.26, 0.99);
 }


### PR DESCRIPTION
initially setting images as position absolute, then only setting to position relative once size has been calculated by justifiedLayout plugin