### PR TITLE
Harden + unify CI image builds (no AWS/secret/registry access on PRs)

### DIFF
--- a/.docker/dockerfiles/base.Dockerfile
+++ b/.docker/dockerfiles/base.Dockerfile
@@ -43,13 +43,18 @@ COPY package.json yarn.lock $APP_HOME/
 RUN yarn install --production=true && \
     rm -rf /usr/local/share/.cache/yarn
 
+# Absent secret (no license mounted) → skip the download and ship without the
+# GeoLite2 DB. Only PR build-validate does this; published main builds mount the
+# real license and bake the DB.
 RUN --mount=type=secret,id=max_mind_license \
-    MAX_MIND_LICENSE="$(cat /run/secrets/max_mind_license)" && \
-    curl -L "https://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-City&license_key=$MAX_MIND_LICENSE&suffix=tar.gz" -o ./GeoLite2-City.tar.gz && \
-    gzip -d GeoLite2-City.tar.gz && \
-    tar -xvf GeoLite2-City.tar && \
     mkdir -p /var/opt/maxmind/ && \
-    mv GeoLite2-City_*/GeoLite2-City.mmdb /var/opt/maxmind/GeoLite2-City.mmdb
+    if [ -s /run/secrets/max_mind_license ]; then \
+      MAX_MIND_LICENSE="$(cat /run/secrets/max_mind_license)" && \
+      curl -L "https://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-City&license_key=$MAX_MIND_LICENSE&suffix=tar.gz" -o ./GeoLite2-City.tar.gz && \
+      gzip -d GeoLite2-City.tar.gz && \
+      tar -xvf GeoLite2-City.tar && \
+      mv GeoLite2-City_*/GeoLite2-City.mmdb /var/opt/maxmind/GeoLite2-City.mmdb; \
+    fi
 
 RUN addgroup -g 1000 -S docker && \
     adduser -u 1000 -S -G docker docker
@@ -59,8 +64,8 @@ COPY --chown=docker:docker . $APP_HOME
 # SITE_HOST: placeholder so the production env boots for assets:precompile —
 # sitemap_generator 7's railtie calls full_url_for on default_url_options at init.
 # The real host comes from SITE_HOST at runtime.
-RUN --mount=type=secret,id=grecaptcha_site_key \
-    export GRECAPTCHA_SITE_KEY="$(cat /run/secrets/grecaptcha_site_key)" && \
+ARG GRECAPTCHA_SITE_KEY=""
+RUN export GRECAPTCHA_SITE_KEY="$GRECAPTCHA_SITE_KEY" && \
     export SECRET_KEY_BASE=1234567890 && \
     export SITE_HOST=localhost && \
     bundle exec rails assets:precompile && \

--- a/.docker/dockerfiles/base.Dockerfile
+++ b/.docker/dockerfiles/base.Dockerfile
@@ -43,9 +43,10 @@ COPY package.json yarn.lock $APP_HOME/
 RUN yarn install --production=true && \
     rm -rf /usr/local/share/.cache/yarn
 
-# Absent secret (no license mounted) → skip the download and ship without the
-# GeoLite2 DB. Only PR build-validate does this; published main builds mount the
-# real license and bake the DB.
+# Absent secret (no license mounted) → skip the download and leave an empty
+# placeholder so the app/worker `COPY --from` of this path still resolves. Only
+# PR build-validate does this; published main builds mount the real license and
+# bake the DB.
 RUN --mount=type=secret,id=max_mind_license \
     mkdir -p /var/opt/maxmind/ && \
     if [ -s /run/secrets/max_mind_license ]; then \
@@ -54,6 +55,8 @@ RUN --mount=type=secret,id=max_mind_license \
       gzip -d GeoLite2-City.tar.gz && \
       tar -xvf GeoLite2-City.tar && \
       mv GeoLite2-City_*/GeoLite2-City.mmdb /var/opt/maxmind/GeoLite2-City.mmdb; \
+    else \
+      touch /var/opt/maxmind/GeoLite2-City.mmdb; \
     fi
 
 RUN addgroup -g 1000 -S docker && \

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# Paths that can execute code or reach secrets/prod in CI. Changes here require
+# an explicit code-owner review, so a compromised Dependabot PR can't auto-merge
+# a CI/infra takeover. CODEOWNERS lives under .github/, so it guards itself.
+/.github/          @cpcwood
+/infrastructure/   @cpcwood
+/.docker/          @cpcwood

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,119 @@
+name: build-images
+
+# Builds every production image in one job: base and worker-dependencies stay in
+# a job-local registry, and app/worker are assembled from THIS run's base via
+# build-contexts. Only app and worker are published to GHCR, and only when
+# `push` is set (main). PR callers pass push=false → no GHCR write, no AWS OIDC,
+# no secrets: the MaxMind download is skipped (no license mounted) and the public
+# reCAPTCHA site key is a placeholder. Permissions come from the calling job.
+on:
+  workflow_call:
+    inputs:
+      push:
+        description: Publish app and worker to GHCR by SHA (main only).
+        type: boolean
+        default: false
+
+env:
+  AWS_REGION: eu-west-2
+  AWS_OIDC_ROLE: ${{ vars.AWS_OIDC_ROLE_ARN }}
+  AWS_SECRET_PREFIX: /cpcwood-k8s/home-server/production
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    services:
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      # network=host lets the builder reach the job-local registry:2 on
+      # localhost:5000, which it talks to over plain HTTP.
+      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+        with:
+          driver-opts: |
+            image=mirror.gcr.io/moby/buildkit:buildx-stable-1
+            network=host
+          buildkitd-config-inline: |
+            [registry."docker.io"]
+              mirrors = ["mirror.gcr.io"]
+            [registry."localhost:5000"]
+              http = true
+      - if: inputs.push
+        uses: aws-actions/configure-aws-credentials@254c19bd240aabef8777f48595e9d2d7b972184b # v6.2.1
+        with:
+          role-to-assume: ${{ env.AWS_OIDC_ROLE }}
+          aws-region: ${{ env.AWS_REGION }}
+      - id: build_secrets
+        if: inputs.push
+        run: |
+          set -euo pipefail
+          json=$(aws ssm get-parameter \
+            --name "${AWS_SECRET_PREFIX}/build" \
+            --with-decryption \
+            --query Parameter.Value \
+            --output text)
+          mml=$(jq -r .MAX_MIND_LICENSE <<<"$json")
+          echo "::add-mask::$mml"
+          echo "BUILD_MAX_MIND_LICENSE=$mml" >> "$GITHUB_ENV"
+          # Public (ships in the client JS bundle) — a build arg, not a secret;
+          # sourced here only because it already lives in the build param.
+          echo "BUILD_GRECAPTCHA_SITE_KEY=$(jq -r .GRECAPTCHA_SITE_KEY <<<"$json")" >> "$GITHUB_ENV"
+      - if: inputs.push
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      # base: real GeoLite2 DB when a license is mounted (main), skipped otherwise
+      # (PR validate). Kept in the job-local registry, never published.
+      - name: Build base
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        with:
+          context: .
+          file: ./.docker/dockerfiles/base.Dockerfile
+          push: true
+          tags: localhost:5000/home-server-base:build
+          secret-envs: ${{ inputs.push && 'max_mind_license=BUILD_MAX_MIND_LICENSE' || '' }}
+          build-args: |
+            GRECAPTCHA_SITE_KEY=${{ inputs.push && env.BUILD_GRECAPTCHA_SITE_KEY || 'pr-validate-placeholder' }}
+          cache-from: type=gha,scope=base
+          cache-to: type=gha,mode=max,scope=base
+      - name: Build worker-dependencies
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        with:
+          context: .
+          file: ./.docker/dockerfiles/worker-dependencies.Dockerfile
+          push: true
+          tags: localhost:5000/home-server-worker-dependencies:build
+          cache-from: type=gha,scope=worker-dependencies
+          cache-to: type=gha,mode=max,scope=worker-dependencies
+      - name: Build app
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        with:
+          context: .
+          file: ./.docker/dockerfiles/Dockerfile
+          push: ${{ inputs.push }}
+          build-contexts: |
+            cpcwood/home-server-base=docker-image://localhost:5000/home-server-base:build
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/home-server-app:${{ github.sha }}
+            ghcr.io/${{ github.repository_owner }}/home-server-app:latest
+          cache-from: type=gha,scope=app
+          cache-to: type=gha,mode=max,scope=app
+      - name: Build worker
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        with:
+          context: .
+          file: ./.docker/dockerfiles/worker.Dockerfile
+          push: ${{ inputs.push }}
+          build-contexts: |
+            cpcwood/home-server-base=docker-image://localhost:5000/home-server-base:build
+            cpcwood/home-server-worker-dependencies=docker-image://localhost:5000/home-server-worker-dependencies:build
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/home-server-worker:${{ github.sha }}
+            ghcr.io/${{ github.repository_owner }}/home-server-worker:latest
+          cache-from: type=gha,scope=worker
+          cache-to: type=gha,mode=max,scope=worker

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,9 +12,6 @@ on:
 env:
   AWS_REGION: eu-west-2
   AWS_OIDC_ROLE: ${{ vars.AWS_OIDC_ROLE_ARN }}
-  # Mirrors local.secret_prefix in infrastructure/terraform/secrets.tf (leading
-  # slash is the Parameter Store convention).
-  AWS_SECRET_PREFIX: /cpcwood-k8s/home-server/production
   # Always re-evaluate the flake rather than trust a cached drv path — guards
   # against the dangling-drv error (NixOS/nix#4236) if a restored store is stale.
   NIX_CONFIG: "eval-cache = false"
@@ -353,238 +350,34 @@ jobs:
       - run: terraform plan -out=tfplan
       - run: terraform apply -auto-approve tfplan
 
-  # main only. Images build in two phases so app/worker are assembled from the
-  # base built THIS run, not a stale registry copy. Phase 1 (build-base) builds +
-  # pushes base and worker-dependencies to GHCR by commit SHA; phase 2 (build-app)
-  # remaps the Dockerfiles' `COPY --from=cpcwood/home-server-*` to those fresh
-  # images via build-contexts. PRs don't run these — they validate the same
-  # builds locally in build-pr, with no GHCR/AWS credentials.
-  build-base:
+  # Build + publish app and worker to GHCR by SHA (base/worker-deps stay
+  # job-local). See build.yml — main and PR share the same build via workflow_call.
+  build-main:
     needs: [test, helm-validate, lint]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
     permissions:
       id-token: write
       contents: read
       packages: write
-    strategy:
-      matrix:
-        image:
-          - name: base
-            dockerfile: ./.docker/dockerfiles/base.Dockerfile
-            needs_build_secrets: true
-          - name: worker-dependencies
-            dockerfile: ./.docker/dockerfiles/worker-dependencies.Dockerfile
-            needs_build_secrets: false
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: aws-actions/configure-aws-credentials@254c19bd240aabef8777f48595e9d2d7b972184b # v6.2.1
-        if: matrix.image.needs_build_secrets
-        with:
-          role-to-assume: ${{ env.AWS_OIDC_ROLE }}
-          aws-region: ${{ env.AWS_REGION }}
-      # Only `base` fetches build-time secrets, so only it pays the nix-install cost.
-      - uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
-        if: matrix.image.needs_build_secrets
-        with:
-          determinate: false
-          extra-conf: |
-            auto-optimise-store = false
-      - uses: nix-community/cache-nix-action@7df957e333c1e5da7721f60227dbba6d06080569 # v7
-        if: matrix.image.needs_build_secrets
-        with:
-          primary-key: nix6-${{ runner.os }}-${{ hashFiles('infrastructure/flake.nix', 'infrastructure/flake.lock') }}
-          purge: true
-          purge-prefixes: nix6-${{ runner.os }}-
-          purge-created: 0
-          purge-last-accessed: 604800
-          purge-primary-key: never
-      - uses: nicknovitski/nix-develop@9be7cfb4b10451d3390a75dc18ad0465bed4932a # v1
-        if: matrix.image.needs_build_secrets
-        with:
-          arguments: ./infrastructure
-      - id: build_secrets
-        if: matrix.image.needs_build_secrets
-        run: |
-          set -euo pipefail
-          json=$(aws ssm get-parameter \
-            --name "${AWS_SECRET_PREFIX}/build" \
-            --with-decryption \
-            --query Parameter.Value \
-            --output text)
-          mml=$(jq -r .MAX_MIND_LICENSE <<<"$json")
-          echo "::add-mask::$mml"
-          echo "BUILD_MAX_MIND_LICENSE=$mml" >> "$GITHUB_ENV"
-          # Public (ships in the client JS bundle) — passed as a build arg below,
-          # not a secret; sourced here only because it already lives in the param.
-          echo "BUILD_GRECAPTCHA_SITE_KEY=$(jq -r .GRECAPTCHA_SITE_KEY <<<"$json")" >> "$GITHUB_ENV"
-      - id: args
-        run: |
-          if [[ "${{ matrix.image.needs_build_secrets }}" == "true" ]]; then
-            cat >>"$GITHUB_OUTPUT" <<'EOF'
-          secret_envs<<SE_EOF
-          max_mind_license=BUILD_MAX_MIND_LICENSE
-          SE_EOF
-          EOF
-          else
-            echo "secret_envs=" >>"$GITHUB_OUTPUT"
-          fi
-      # Pull buildkit + the Dockerfiles' base images through Google's public
-      # docker.io mirror to dodge Docker Hub anonymous rate limits / timeouts.
-      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
-        with:
-          driver-opts: image=mirror.gcr.io/moby/buildkit:buildx-stable-1
-          buildkitd-config-inline: |
-            [registry."docker.io"]
-              mirrors = ["mirror.gcr.io"]
-      - uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
-        with:
-          context: .
-          file: ${{ matrix.image.dockerfile }}
-          push: true
-          tags: |
-            ghcr.io/${{ github.repository_owner }}/home-server-${{ matrix.image.name }}:${{ github.sha }}
-            ghcr.io/${{ github.repository_owner }}/home-server-${{ matrix.image.name }}:latest
-          secret-envs: ${{ steps.args.outputs.secret_envs }}
-          # Unused by worker-dependencies (empty there — harmless).
-          build-args: |
-            GRECAPTCHA_SITE_KEY=${{ env.BUILD_GRECAPTCHA_SITE_KEY }}
-          cache-from: type=gha,scope=${{ matrix.image.name }}
-          cache-to: type=gha,mode=max,scope=${{ matrix.image.name }}
+    uses: ./.github/workflows/build.yml
+    with:
+      push: true
 
-  build-app:
-    needs: [build-base]
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-    strategy:
-      matrix:
-        image:
-          - name: app
-            dockerfile: ./.docker/dockerfiles/Dockerfile
-          - name: worker
-            dockerfile: ./.docker/dockerfiles/worker.Dockerfile
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
-        with:
-          driver-opts: image=mirror.gcr.io/moby/buildkit:buildx-stable-1
-          buildkitd-config-inline: |
-            [registry."docker.io"]
-              mirrors = ["mirror.gcr.io"]
-      # Log in to pull the freshly-pushed (private) base/worker-deps, and to push
-      # app/worker on main.
-      - uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      # Remap each Dockerfile's `COPY --from=cpcwood/home-server-*` to the image
-      # built this run, so app/worker carry current code rather than a stale copy.
-      - id: ctx
-        run: |
-          repo="ghcr.io/${{ github.repository_owner }}"
-          sha="${{ github.sha }}"
-          {
-            echo "contexts<<CTX_EOF"
-            echo "cpcwood/home-server-base=docker-image://${repo}/home-server-base:${sha}"
-            if [[ "${{ matrix.image.name }}" == "worker" ]]; then
-              echo "cpcwood/home-server-worker-dependencies=docker-image://${repo}/home-server-worker-dependencies:${sha}"
-            fi
-            echo "CTX_EOF"
-          } >> "$GITHUB_OUTPUT"
-      - uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
-        with:
-          context: .
-          file: ${{ matrix.image.dockerfile }}
-          build-contexts: ${{ steps.ctx.outputs.contexts }}
-          push: true
-          tags: |
-            ghcr.io/${{ github.repository_owner }}/home-server-${{ matrix.image.name }}:${{ github.sha }}
-            ghcr.io/${{ github.repository_owner }}/home-server-${{ matrix.image.name }}:latest
-          cache-from: type=gha,scope=${{ matrix.image.name }}
-          cache-to: type=gha,mode=max,scope=${{ matrix.image.name }}
-
-  # PR image build-validate. Builds every production image from THIS run's base
-  # via a job-local registry, so a dependency bump that breaks the image build
-  # fails the PR — without pushing anything, and without AWS OIDC or GHCR write
-  # credentials. No secrets needed: the MaxMind download is skipped (no license
-  # mounted) and the reCAPTCHA site key is a public build arg.
+  # PR build-validate: same build, no push, no AWS OIDC, no GHCR write, no
+  # secrets. A dependency bump that breaks the image build fails the PR.
   build-pr:
     needs: [test, helm-validate, lint]
     if: |
       github.event_name == 'pull_request' &&
       github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: ubuntu-latest
     permissions:
       contents: read
-    services:
-      registry:
-        image: registry:2
-        ports:
-          - 5000:5000
-    steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      # network=host lets the builder reach the job-local registry:2 on
-      # localhost:5000, which it talks to over plain HTTP.
-      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
-        with:
-          driver-opts: |
-            image=mirror.gcr.io/moby/buildkit:buildx-stable-1
-            network=host
-          buildkitd-config-inline: |
-            [registry."docker.io"]
-              mirrors = ["mirror.gcr.io"]
-            [registry."localhost:5000"]
-              http = true
-      - name: Build base (validate; geo DB skipped, not published)
-        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
-        with:
-          context: .
-          file: ./.docker/dockerfiles/base.Dockerfile
-          push: true
-          tags: localhost:5000/home-server-base:pr
-          # Validate-only build; the real (public) site key is injected on main.
-          build-args: |
-            GRECAPTCHA_SITE_KEY=pr-validate-placeholder
-          cache-from: type=gha,scope=base
-      - name: Build worker-dependencies (validate)
-        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
-        with:
-          context: .
-          file: ./.docker/dockerfiles/worker-dependencies.Dockerfile
-          push: true
-          tags: localhost:5000/home-server-worker-dependencies:pr
-          cache-from: type=gha,scope=worker-dependencies
-      - name: Build app (validate; not pushed)
-        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
-        with:
-          context: .
-          file: ./.docker/dockerfiles/Dockerfile
-          push: false
-          build-contexts: |
-            cpcwood/home-server-base=docker-image://localhost:5000/home-server-base:pr
-          cache-from: type=gha,scope=app
-      - name: Build worker (validate; not pushed)
-        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
-        with:
-          context: .
-          file: ./.docker/dockerfiles/worker.Dockerfile
-          push: false
-          build-contexts: |
-            cpcwood/home-server-base=docker-image://localhost:5000/home-server-base:pr
-            cpcwood/home-server-worker-dependencies=docker-image://localhost:5000/home-server-worker-dependencies:pr
-          cache-from: type=gha,scope=worker
+    uses: ./.github/workflows/build.yml
+    with:
+      push: false
 
   deploy:
-    needs: [terraform, build-app]
+    needs: [terraform, build-main]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -168,9 +168,13 @@ jobs:
   # values; a fork PR could craft a `nonsensitive()` output to exfiltrate.
   terraform-plan:
     needs: [lint]
+    # Skip Dependabot: its PRs are denied Actions secrets, so KUBE_CONFIG_DATA
+    # is empty and the plan can't reach the cluster. Don't grant a Dependabot
+    # secret to fix it — it carries prod-namespace admin, and bumps never touch terraform.
     if: |
       github.event_name == 'pull_request' &&
-      github.event.pull_request.head.repo.full_name == github.repository
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -275,7 +279,7 @@ jobs:
   # always() so it runs (and reports) even when a needed job fails; skipped
   # needs (e.g. fork PRs) don't count as failures.
   ci-gate:
-    needs: [test, helm-validate, lint, terraform-plan, build-base, build-app]
+    needs: [test, helm-validate, lint, terraform-plan, build-pr]
     if: always() && github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
@@ -349,18 +353,15 @@ jobs:
       - run: terraform plan -out=tfplan
       - run: terraform apply -auto-approve tfplan
 
-  # Images build in two phases so app/worker are assembled from the base built
-  # THIS run, not a stale registry copy. Phase 1 (build-base) builds + pushes
-  # base and worker-dependencies to GHCR by commit SHA; phase 2 (build-app)
+  # main only. Images build in two phases so app/worker are assembled from the
+  # base built THIS run, not a stale registry copy. Phase 1 (build-base) builds +
+  # pushes base and worker-dependencies to GHCR by commit SHA; phase 2 (build-app)
   # remaps the Dockerfiles' `COPY --from=cpcwood/home-server-*` to those fresh
-  # images via build-contexts. Same-repo PRs run both (base is pushed by SHA so
-  # phase 2 can pull it; app/worker are built but not published). Fork PRs are
-  # excluded — no OIDC for the base build secrets.
+  # images via build-contexts. PRs don't run these — they validate the same
+  # builds locally in build-pr, with no GHCR/AWS credentials.
   build-base:
     needs: [test, helm-validate, lint]
-    if: |
-      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
-      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -412,18 +413,17 @@ jobs:
             --query Parameter.Value \
             --output text)
           mml=$(jq -r .MAX_MIND_LICENSE <<<"$json")
-          grck=$(jq -r .GRECAPTCHA_SITE_KEY <<<"$json")
           echo "::add-mask::$mml"
-          echo "::add-mask::$grck"
           echo "BUILD_MAX_MIND_LICENSE=$mml" >> "$GITHUB_ENV"
-          echo "BUILD_GRECAPTCHA_SITE_KEY=$grck" >> "$GITHUB_ENV"
+          # Public (ships in the client JS bundle) — passed as a build arg below,
+          # not a secret; sourced here only because it already lives in the param.
+          echo "BUILD_GRECAPTCHA_SITE_KEY=$(jq -r .GRECAPTCHA_SITE_KEY <<<"$json")" >> "$GITHUB_ENV"
       - id: args
         run: |
           if [[ "${{ matrix.image.needs_build_secrets }}" == "true" ]]; then
             cat >>"$GITHUB_OUTPUT" <<'EOF'
           secret_envs<<SE_EOF
           max_mind_license=BUILD_MAX_MIND_LICENSE
-          grecaptcha_site_key=BUILD_GRECAPTCHA_SITE_KEY
           SE_EOF
           EOF
           else
@@ -437,7 +437,6 @@ jobs:
           buildkitd-config-inline: |
             [registry."docker.io"]
               mirrors = ["mirror.gcr.io"]
-      # Always log in: base is pushed by SHA on PRs too, so phase 2 can pull it.
       - uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ghcr.io
@@ -450,16 +449,17 @@ jobs:
           push: true
           tags: |
             ghcr.io/${{ github.repository_owner }}/home-server-${{ matrix.image.name }}:${{ github.sha }}
-            ${{ github.event_name == 'push' && format('ghcr.io/{0}/home-server-{1}:latest', github.repository_owner, matrix.image.name) || '' }}
+            ghcr.io/${{ github.repository_owner }}/home-server-${{ matrix.image.name }}:latest
           secret-envs: ${{ steps.args.outputs.secret_envs }}
+          # Unused by worker-dependencies (empty there — harmless).
+          build-args: |
+            GRECAPTCHA_SITE_KEY=${{ env.BUILD_GRECAPTCHA_SITE_KEY }}
           cache-from: type=gha,scope=${{ matrix.image.name }}
           cache-to: type=gha,mode=max,scope=${{ matrix.image.name }}
 
   build-app:
     needs: [build-base]
-    if: |
-      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
-      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -505,13 +505,83 @@ jobs:
           context: .
           file: ${{ matrix.image.dockerfile }}
           build-contexts: ${{ steps.ctx.outputs.contexts }}
-          # Push only on main; PR runs build-validate without publishing.
-          push: ${{ github.event_name == 'push' }}
+          push: true
           tags: |
             ghcr.io/${{ github.repository_owner }}/home-server-${{ matrix.image.name }}:${{ github.sha }}
-            ${{ github.event_name == 'push' && format('ghcr.io/{0}/home-server-{1}:latest', github.repository_owner, matrix.image.name) || '' }}
+            ghcr.io/${{ github.repository_owner }}/home-server-${{ matrix.image.name }}:latest
           cache-from: type=gha,scope=${{ matrix.image.name }}
           cache-to: type=gha,mode=max,scope=${{ matrix.image.name }}
+
+  # PR image build-validate. Builds every production image from THIS run's base
+  # via a job-local registry, so a dependency bump that breaks the image build
+  # fails the PR — without pushing anything, and without AWS OIDC or GHCR write
+  # credentials. No secrets needed: the MaxMind download is skipped (no license
+  # mounted) and the reCAPTCHA site key is a public build arg.
+  build-pr:
+    needs: [test, helm-validate, lint]
+    if: |
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    services:
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      # network=host lets the builder reach the job-local registry:2 on
+      # localhost:5000, which it talks to over plain HTTP.
+      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+        with:
+          driver-opts: |
+            image=mirror.gcr.io/moby/buildkit:buildx-stable-1
+            network=host
+          buildkitd-config-inline: |
+            [registry."docker.io"]
+              mirrors = ["mirror.gcr.io"]
+            [registry."localhost:5000"]
+              http = true
+      - name: Build base (validate; geo DB skipped, not published)
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        with:
+          context: .
+          file: ./.docker/dockerfiles/base.Dockerfile
+          push: true
+          tags: localhost:5000/home-server-base:pr
+          # Validate-only build; the real (public) site key is injected on main.
+          build-args: |
+            GRECAPTCHA_SITE_KEY=pr-validate-placeholder
+          cache-from: type=gha,scope=base
+      - name: Build worker-dependencies (validate)
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        with:
+          context: .
+          file: ./.docker/dockerfiles/worker-dependencies.Dockerfile
+          push: true
+          tags: localhost:5000/home-server-worker-dependencies:pr
+          cache-from: type=gha,scope=worker-dependencies
+      - name: Build app (validate; not pushed)
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        with:
+          context: .
+          file: ./.docker/dockerfiles/Dockerfile
+          push: false
+          build-contexts: |
+            cpcwood/home-server-base=docker-image://localhost:5000/home-server-base:pr
+          cache-from: type=gha,scope=app
+      - name: Build worker (validate; not pushed)
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        with:
+          context: .
+          file: ./.docker/dockerfiles/worker.Dockerfile
+          push: false
+          build-contexts: |
+            cpcwood/home-server-base=docker-image://localhost:5000/home-server-base:pr
+            cpcwood/home-server-worker-dependencies=docker-image://localhost:5000/home-server-worker-dependencies:pr
+          cache-from: type=gha,scope=worker
 
   deploy:
     needs: [terraform, build-app]

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Pre-flight check: `kubectl get clustersecretstore aws-parameter-store` should be
 
 One-time clicks that can't (sensibly) be scripted:
 
-- **GHCR package access** — after the first `build` run, packages `home-server-base`, `home-server-app`, `home-server-worker`, `home-server-worker-dependencies` appear at https://github.com/cpcwood?tab=packages. For each: *Package settings → Manage Actions access → Add Repository* → `home-server` with **Write**. To let the cluster pull without auth, also set visibility to **Public**.
+- **GHCR package access** — after the first `main` build, packages `home-server-app` and `home-server-worker` appear at https://github.com/cpcwood?tab=packages (base and worker-dependencies are built in a job-local registry and never published). For each: *Package settings → Manage Actions access → Add Repository* → `home-server` with **Write**. To let the cluster pull without auth, also set visibility to **Public**.
 - **Auto-merge for Dependabot** — *Settings → General → Pull Requests* → enable **Allow auto-merge**. Then *Settings → Branches → Branch protection rules* for `main`: require a PR, require status checks (`test`, `helm-validate`, `terraform-validate`), require up-to-date branches. Without these the `automerge` job has no gate to wait on.
 
 


### PR DESCRIPTION
## Why

Pull-request runs were reaching production credentials. The old `build-base` ran on same-repo PRs with GitHub OIDC + SSM access and pushed images to GHCR. Because a `pull_request` run executes the workflow file **from the PR head**, a malicious/compromised PR could assume the AWS role (reading SSM SecureStrings) or write the registry — no merge required. Separately, `terraform-plan` failed on every Dependabot PR (Dependabot runs can't read the `KUBE_CONFIG_DATA` Actions secret → k8s provider fell back to `localhost`).

## What changed

**Unified image build (`build.yml`, `workflow_call`).** The old `build-base` + `build-app` split existed only to courier the base image between runners via GHCR — nothing else consumes `home-server-base`/`worker-dependencies`. Collapsed into one job that keeps base + worker-deps in a **job-local `registry:2`** and publishes **only `app` + `worker`** to GHCR, and only when the caller sets `push: true`.

- `build-main` (push to main) → `build.yml` with `push: true`: real GeoLite2 DB (SSM license via OIDC), pushes app+worker by SHA. `deploy` now needs `build-main`.
- `build-pr` (same-repo PR) → `build.yml` with `push: false`: **no push, no AWS OIDC, no GHCR write, no secrets**. MaxMind skipped, reCAPTCHA placeholder. Still fails the PR if a bump breaks the build.
- Permissions come from the caller job (PR grants only `contents: read`).

**Dockerfile:** MaxMind download skipped when no license is mounted; the **public** reCAPTCHA site key is a plain build arg (it ships in the client JS anyway).

**`terraform-plan`:** skipped for Dependabot.

**`CODEOWNERS`:** review required on `/.github/`, `/infrastructure/`, `/.docker/`.

Also drops the nix install from the build path (only `aws`+`jq` are needed, both preinstalled), the dead `AWS_SECRET_PREFIX` env, and two published GHCR packages. Net −88 lines in `main.yml`.

## Verify on first CI run
The **job-local registry wiring** (`network=host` + insecure `localhost:5000`, shared by `build.yml`) is the one piece not verifiable locally. YAML, job graph, and Dockerfile logic are verified. The `main` deploy path is unchanged in behaviour (still builds real images and pushes app+worker by SHA).

## Deliberately deferred
- **`iam.tf` trust scoping** — after this PR the only PR consumer of `pull_request` OIDC is your own (non-Dependabot) `terraform-plan`; dropping it breaks that for no Dependabot gain. Full closure = Environment-gated apply role (follow-up).
- **Deploy by image digest** — supply-chain hardening on the deploy reference; own change.

## Manual follow-ups (can't be done from a PR)
1. **Branch protection** — CODEOWNERS is inert until `main` requires code-owner review (`gh api …/branches/main/protection`, count `0` to keep dep-bump auto-merge).
2. **`DEPENDABOT_AUTOMERGE_TOKEN`** — add to the **Dependabot** secret store so `automerge` works.